### PR TITLE
Fix: Header Tag Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CSS columns are pretty well supported: http://caniuse.com/#feat=multicolumn
 ```handlebars
 <div class="masonry-wall">
 	<div class="masonry-brick">
-		<h1>Some big content<br /><br/>More stuff</h2>
+		<h1>Some big content<br /><br/>More stuff</h1>
 	</div>
 	<div class="masonry-brick masonry-no-break"><!-- will not wrap content to next column-->
 		<h6>Some <small>not as big</small> content</h6>


### PR DESCRIPTION
This is really trivial but it will throw a bug if someone tries out your example code :)